### PR TITLE
11.0.0.2

### DIFF
--- a/BankItems.lua
+++ b/BankItems.lua
@@ -4688,7 +4688,7 @@ function bankStackReduction(tab, reduction)
 			if sortTab[i] == tab[j] then
 				sortTab[i] = tab[j] - reduction
 				if sortTab[i] < 0 then
-					print(i, j, reduction)
+					--print(i, j, reduction)
 					reduction = reduction - tab[j]
 					tab[j] = 0
 				else
@@ -7616,6 +7616,16 @@ function BankItems_AddTooltipData(self, ...)
 			end
 			
 			for a, _ in pairs(alts) do
+				-- reset to re-use
+				baginfos[1][2] = 0
+				baginfos[2][2] = 0
+				baginfos[3][2] = 0
+				baginfos[4][2] = 0
+				baginfos[5][2] = 0
+				baginfos[6][2] = 0
+				baginfos[7][2] = 0
+				baginfos[8][2] = 0
+			
 				local counttable1, counttable2, counttable3 
 				if BankItems_Cache[q[1]] then counttable1 = BankItems_Cache[q[1]][a] end
 				if BankItems_Cache[q[2]] then counttable2 = BankItems_Cache[q[2]][a] end
@@ -7856,9 +7866,16 @@ function BankItems_AddTooltipData(self, ...)
 				end
 			end
 		end
-		if characters > 1 then
-			tinsert(BankItems_TooltipCache[item], L["Total: %d"]:format(totalCount))
-		end
+		
+		-- reset to re-use
+		baginfos[1][2] = 0
+		baginfos[2][2] = 0
+		baginfos[3][2] = 0
+		baginfos[4][2] = 0
+		baginfos[5][2] = 0
+		baginfos[6][2] = 0
+		baginfos[7][2] = 0
+		baginfos[8][2] = 0
 		
 		-- ACCOUNT BANKS
 		if quality then
@@ -7927,16 +7944,18 @@ function BankItems_AddTooltipData(self, ...)
 				baginfos[8][2] = (baginfos[8][2] or 0) + (counttable3.reagentbank or 0)
 			end
 			
-			local text
+			local text 
 			local name = "Warband"
 			
-			text = format("[%s] %s ", name, L["has"])
+			if counttable1 or counttable2 or counttable3 then text = format("[%s] %s ", name, L["has"]) end
 			if counttable1 then text = text..format("%d%s", counttable1.count, icon1) end
 			if counttable2 then text = text..format("%d%s", counttable2.count, icon2) end
 			if counttable3 then text = text..format("%d%s", counttable3.count, icon3) end
 
-			tinsert(BankItems_TooltipCache[item], text)
-			characters = characters + 1
+			if text then 
+				tinsert(BankItems_TooltipCache[item], text) 
+				characters = characters + 1
+			end
 
 		else
 			if BankItems_AccountCache[item] then

--- a/BankItems.toc
+++ b/BankItems.toc
@@ -2,7 +2,7 @@
 ## Title: BankItems
 ## Title-zhCN: 离线银行 BankItems
 ## Title-zhTW: 離線銀行 BankItems
-## Version: 11.0.0.1
+## Version: 11.0.0.2
 ## Notes: View bank, inventory, mail, equipped and guild bank contents from any character anywhere!
 ## Notes-koKR: 은행, 가방, 우편, 착용한 장비, 길드 금고의 내용물을 어디서나 어떤 캐릭터로도 볼 수 있습니다!
 ## Notes-ruRU: Просмотр содержимого банка, банка гильдии, инвентаря, почты любого вашего персонажа везде и в любое время!

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,10 @@
 ------------------------------------------------------------------------
+11.0.0.2 | Centias | 2024-08-06 20:31:15
+
+Update: Fix for Warband line when item is not in Warbank
+	Fix for duplicate Total lines
+	Fix for some tallying variables not being reset between characters for tooltips leading to inaccurate quantities
+------------------------------------------------------------------------
 11.0.0.1 | Centias | 2024-07-28 02:06:38
 
 Update: Fixes for TWW pre-patch and most of the work for getting Warband Storage working with existing functions


### PR DESCRIPTION
Fix for Warband line when item is not in Warbank
Fix for duplicate Total lines
Fix for some tallying variables not being reset between characters for tooltips leading to inaccurate quantities